### PR TITLE
sdk: Add an option to force pre-O apps to use full screen aspect ratio

### DIFF
--- a/lineage/res/res/values/config.xml
+++ b/lineage/res/res/values/config.xml
@@ -240,4 +240,7 @@
     <!-- Indicate whether encryption causes significant performances loss.
          This MUST NOT be set to true on devices produced in 2016 or later -->
     <bool name="config_trustLegacyEncryption">false</bool>
+
+    <!-- Whether device has a screen with a higher aspect ratio -->
+    <bool name="config_haveHigherAspectRatioScreen">false</bool>
 </resources>

--- a/lineage/res/res/values/symbols.xml
+++ b/lineage/res/res/values/symbols.xml
@@ -179,4 +179,7 @@
     <java-symbol type="string" name="trust_notification_title_onboarding" />
     <java-symbol type="string" name="trust_notification_content_onboarding" />
     <java-symbol type="string" name="trust_notification_action_later" />
+
+    <!-- Full screen aspect ratio -->
+    <java-symbol type="bool" name="config_haveHigherAspectRatioScreen" />
 </resources>

--- a/sdk/src/java/lineageos/providers/LineageSettings.java
+++ b/sdk/src/java/lineageos/providers/LineageSettings.java
@@ -2030,6 +2030,15 @@ public final class LineageSettings {
                 sNonNegativeIntegerValidator;
 
         /**
+         * List of long-screen apps.
+         */
+        public static final String LONG_SCREEN_APPS = "long_screen_apps";
+
+        /** @hide */
+        public static final Validator LONG_SCREEN_APPS_VALIDATOR =
+                sAlwaysTrueValidator;
+
+        /**
          * I can haz more bukkits
          * @hide
          */
@@ -2318,6 +2327,8 @@ public final class LineageSettings {
                     DISPLAY_PICTURE_ADJUSTMENT_VALIDATOR);
             VALIDATORS.put(ACCELEROMETER_ROTATION_ANGLES,
                     ACCELEROMETER_ROTATION_ANGLES_VALIDATOR);
+            VALIDATORS.put(LONG_SCREEN_APPS,
+                    LONG_SCREEN_APPS_VALIDATOR);
             VALIDATORS.put(__MAGICAL_TEST_PASSING_ENABLER,
                     __MAGICAL_TEST_PASSING_ENABLER_VALIDATOR);
         };

--- a/sdk/src/java/org/lineageos/internal/applications/LineageActivityManager.java
+++ b/sdk/src/java/org/lineageos/internal/applications/LineageActivityManager.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2018 The LineageOS project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lineageos.internal.applications;
+
+import android.content.Context;
+
+public class LineageActivityManager {
+    private Context mContext;
+
+    // Long screen related activity settings
+    private LongScreen mLongScreen;
+
+    public LineageActivityManager(Context context) {
+        mContext = context;
+
+        mLongScreen = new LongScreen(context);
+    }
+
+    public boolean shouldForceLongScreen(String packageName) {
+        return mLongScreen.shouldForceLongScreen(packageName);
+    }
+}

--- a/sdk/src/java/org/lineageos/internal/applications/LongScreen.java
+++ b/sdk/src/java/org/lineageos/internal/applications/LongScreen.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2018 The LineageOS project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lineageos.internal.applications;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.res.Resources;
+import android.database.ContentObserver;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.UserHandle;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import lineageos.providers.LineageSettings;
+
+public class LongScreen {
+    private Set<String> mApps = new HashSet<>();
+    private Context mContext;
+
+    private final boolean mLongScreenAvailable;
+
+    public LongScreen(Context context) {
+        mContext = context;
+        final Resources resources = mContext.getResources();
+
+        mLongScreenAvailable = resources.getBoolean(
+                org.lineageos.platform.internal.R.bool.config_haveHigherAspectRatioScreen);
+
+        if (!mLongScreenAvailable) {
+            return;
+        }
+
+        SettingsObserver observer = new SettingsObserver(
+                new Handler(Looper.getMainLooper()));
+        observer.observe();
+    }
+
+    public boolean isSupported() {
+        return mLongScreenAvailable;
+    }
+
+    public boolean shouldForceLongScreen(String packageName) {
+        return isSupported() && mApps.contains(packageName);
+    }
+
+    public Set<String> getApps() {
+        return mApps;
+    }
+
+    public void addApp(String packageName) {
+        mApps.add(packageName);
+        LineageSettings.System.putString(mContext.getContentResolver(),
+                LineageSettings.System.LONG_SCREEN_APPS, String.join(",", mApps));
+    }
+
+    public void removeApp(String packageName) {
+        mApps.remove(packageName);
+        LineageSettings.System.putString(mContext.getContentResolver(),
+                LineageSettings.System.LONG_SCREEN_APPS, String.join(",", mApps));
+    }
+
+    public void setApps(Set<String> apps) {
+        mApps = apps;
+    }
+
+    class SettingsObserver extends ContentObserver {
+        SettingsObserver(Handler handler) {
+            super(handler);
+        }
+
+        void observe() {
+            ContentResolver resolver = mContext.getContentResolver();
+
+            resolver.registerContentObserver(LineageSettings.System.getUriFor(
+                    LineageSettings.System.LONG_SCREEN_APPS), false, this,
+                    UserHandle.USER_ALL);
+
+            update();
+        }
+
+        @Override
+        public void onChange(boolean selfChange) {
+            update();
+        }
+
+        public void update() {
+            ContentResolver resolver = mContext.getContentResolver();
+
+            String apps = LineageSettings.System.getStringForUser(resolver,
+                    LineageSettings.System.LONG_SCREEN_APPS,
+                    UserHandle.USER_CURRENT);
+            if (apps != null) {
+                setApps(new HashSet<>(Arrays.asList(apps.split(","))));
+            } else {
+                setApps(new HashSet<>());
+            }
+        }
+    }
+}


### PR DESCRIPTION
When an app target pre-O releases, the default max aspect ratio
is 1.86:1 which leads to ugly black areas on devices that have
screens with higher aspect ratio (for example Galaxy S8/S9).

This change adds an option to allow users to change aspect ratio
for pre-O apps to full screen aspect ratio.

Change-Id: I2531542f736ee7b809ef7faffd72e5963e7d20d6