### PR TITLE
TrustInterface: Handle unsupported encryption state

### DIFF
--- a/lineage/lib/main/java/org/lineageos/platform/internal/TrustInterfaceService.java
+++ b/lineage/lib/main/java/org/lineageos/platform/internal/TrustInterfaceService.java
@@ -301,6 +301,8 @@ public class TrustInterfaceService extends LineageSystemService {
                 return isOldDevice ?
                         TrustInterface.TRUST_FEATURE_LEVEL_POOR :
                         TrustInterface.TRUST_FEATURE_LEVEL_BAD;
+            case DevicePolicyManager.ENCRYPTION_STATUS_UNSUPPORTED:
+                return TrustInterface.TRUST_FEATURE_LEVEL_BAD;
             default:
                 return TrustInterface.ERROR_UNDEFINED;
         }


### PR DESCRIPTION
 * Some devices might return unsupported, therefore
    explicitly label this state as bad

 * Also applies for special situations where encryption
    is essentially impossible, like booting with
    MultiROM from an external storage

Change-Id: I7752933bad05bf8c67f5ca0d3fba7c5b38833c87