### PR TITLE
sdk: Trust: better warnings management

### DIFF
--- a/api/lineage_current.txt
+++ b/api/lineage_current.txt
@@ -785,7 +785,8 @@ package lineageos.providers {
     method public static boolean putString(android.content.ContentResolver, java.lang.String, java.lang.String);
     field public static final android.net.Uri CONTENT_URI;
     field public static final java.lang.String SYS_PROP_LINEAGE_SETTING_VERSION = "sys.lineage_settings_secure_version";
-    field public static final java.lang.String TRUST_NOTIFICATIONS = "trust_notifications";
+    field public static final deprecated java.lang.String TRUST_NOTIFICATIONS = "trust_notifications";
+    field public static final java.lang.String TRUST_WARNINGS = "trust_warnings";
   }
 
   public static final class LineageSettings.System extends android.provider.Settings.NameValueTable {
@@ -1047,6 +1048,9 @@ package lineageos.trust {
     field public static final int TRUST_FEATURE_SELINUX = 0; // 0x0
     field public static final int TRUST_FEATURE_VENDOR_SECURITY_PATCH = 3; // 0x3
     field public static final java.lang.String TRUST_INTERFACE_PERMISSION = "lineageos.permission.TRUST_INTERFACE";
+    field public static final int TRUST_WARN_PUBLIC_KEY = 4; // 0x4
+    field public static final int TRUST_WARN_ROOT = 2; // 0x2
+    field public static final int TRUST_WARN_SELINUX = 1; // 0x1
   }
 
 }

--- a/lineage/lib/main/java/org/lineageos/platform/internal/TrustInterfaceService.java
+++ b/lineage/lib/main/java/org/lineageos/platform/internal/TrustInterfaceService.java
@@ -49,12 +49,15 @@ import java.util.Date;
 /** @hide **/
 public class TrustInterfaceService extends LineageSystemService {
     private static final String TAG = "LineageTrustInterfaceService";
+
     private static final String PLATFORM_SECURITY_PATCHES = "ro.build.version.security_patch";
     private static final String VENDOR_SECURITY_PATCHES = "ro.vendor.build.security_patch";
     private static final String LINEAGE_VENDOR_SECURITY_PATCHES =
             "ro.lineage.build.vendor_security_patch";
+
     private static final String INTENT_PARTS = "org.lineageos.lineageparts.TRUST_INTERFACE";
     private static final String INTENT_ONBOARDING = "org.lineageos.lineageparts.TRUST_HINT";
+
     private static final String CHANNEL_NAME = "TrustInterface";
     private static final int ONBOARDING_NOTIFCATION_ID = 89;
 
@@ -80,27 +83,20 @@ public class TrustInterfaceService extends LineageSystemService {
     @Override
     public void onStart() {
         mNotificationManager = mContext.getSystemService(NotificationManager.class);
+
         // Onboard
         if (!hasOnboardedUser()) {
             postOnBoardingNotification();
             return;
         }
 
-        int selinuxStatus = getSELinuxStatus();
-        if (selinuxStatus != TrustInterface.TRUST_FEATURE_LEVEL_GOOD) {
-            postNotificationForFeatureInternal(TrustInterface.TRUST_FEATURE_SELINUX);
-        }
-
-        int keysStatus = getKeysStatus();
-        if (keysStatus != TrustInterface.TRUST_FEATURE_LEVEL_GOOD) {
-            postNotificationForFeatureInternal(TrustInterface.TRUST_FEATURE_KEYS);
-        }
+        runTestInternal();
     }
 
     /* Public methods implementation */
 
     private boolean postNotificationForFeatureInternal(int feature) {
-        if (!hasOnboardedUser() || !userAllowsTrustNotifications()) {
+        if (!hasOnboardedUser() || !isWarningAllowed(feature)) {
             return false;
         }
 
@@ -138,7 +134,7 @@ public class TrustInterfaceService extends LineageSystemService {
     }
 
     private boolean removeNotificationForFeatureInternal(int feature) {
-        if (!userAllowsTrustNotifications()) {
+        if (!isWarningAllowed(feature)) {
             return false;
         }
 
@@ -185,6 +181,18 @@ public class TrustInterfaceService extends LineageSystemService {
         }
     }
 
+    private void runTestInternal() {
+        int selinuxStatus = getSELinuxStatus();
+        if (selinuxStatus != TrustInterface.TRUST_FEATURE_LEVEL_GOOD) {
+            postNotificationForFeatureInternal(TrustInterface.TRUST_WARN_SELINUX);
+        }
+
+        int keysStatus = getKeysStatus();
+        if (keysStatus != TrustInterface.TRUST_FEATURE_LEVEL_GOOD) {
+            postNotificationForFeatureInternal(TrustInterface.TRUST_WARN_PUBLIC_KEY);
+        }
+    }
+
     /* Utils */
 
     private void enforceTrustPermission() {
@@ -192,9 +200,10 @@ public class TrustInterfaceService extends LineageSystemService {
                 "You do not have permissions to use the Trust interface");
     }
 
-    private boolean userAllowsTrustNotifications() {
-        return LineageSettings.Secure.getInt(mContext.getContentResolver(),
-                LineageSettings.Secure.TRUST_NOTIFICATIONS, 1) == 1;
+    private boolean isWarningAllowed(int warning) {
+        return (LineageSettings.Secure.getInt(mContext.getContentResolver(),
+                LineageSettings.Secure.TRUST_WARNINGS,
+                TrustInterface.TRUST_WARN_MAX_VALUE) & warning) != 0;
     }
 
     private Pair<Integer, Integer> getNotificationStringsForFeature(int feature) {
@@ -202,15 +211,15 @@ public class TrustInterfaceService extends LineageSystemService {
         int message = 0;
 
         switch (feature) {
-            case TrustInterface.TRUST_FEATURE_SELINUX:
+            case TrustInterface.TRUST_WARN_SELINUX:
                 title = R.string.trust_notification_title_security;
                 message = R.string.trust_notification_content_selinux;
                 break;
-            case TrustInterface.TRUST_FEATURE_ROOT:
+            case TrustInterface.TRUST_WARN_ROOT:
                 title = R.string.trust_notification_title_root;
                 message = R.string.trust_notification_content_root;
                 break;
-            case TrustInterface.TRUST_FEATURE_KEYS:
+            case TrustInterface.TRUST_WARN_PUBLIC_KEY:
                 title = R.string.trust_notification_title_security;
                 message = R.string.trust_notification_content_keys;
                 break;
@@ -372,6 +381,19 @@ public class TrustInterfaceService extends LineageSystemService {
              * No need to require permission for this one because it's harmless
              */
             return getLevelForFeatureInternal(feature);
+        }
+
+        @Override
+        public void runTest() {
+            enforceTrustPermission();
+            /*
+             * We need to clear the caller's identity in order to
+             *   allow this method call to modify settings
+             *   not allowed by the caller's permissions.
+             */
+            long token = clearCallingIdentity();
+            runTestInternal();
+            restoreCallingIdentity(token);
         }
     };
 }

--- a/sdk/src/java/lineageos/providers/LineageSettings.java
+++ b/sdk/src/java/lineageos/providers/LineageSettings.java
@@ -44,6 +44,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import lineageos.trust.TrustInterface;
+
 /**
  * LineageSettings contains Lineage specific preferences in System, Secure, and Global.
  */
@@ -3053,12 +3055,28 @@ public final class LineageSettings {
         /**
          * Enable displaying the Trust service's notifications
          * 0 = 0ff, 1 = on
+         * @deprecated Rely on {@link lineageos.providers.TRUST_WARNINGS} instead
          */
+         @Deprecated
         public static final String TRUST_NOTIFICATIONS = "trust_notifications";
 
         /** @hide */
+        @Deprecated
         public static final Validator TRUST_NOTIFICATIONS_VALIDATOR =
                 sBooleanValidator;
+
+        /**
+         * Trust warnings status
+         *
+         * Stores flags for each feature
+         *
+         * @see {@link lineageos.trust.TrustInterface.TRUST_WARN_MAX_VALUE}
+         */
+        public static final String TRUST_WARNINGS = "trust_warnings";
+
+        /** @hide */
+        public static final Validator TRUST_WARNINGS_VALIDATOR =
+                new InclusiveIntegerRangeValidator(0, TrustInterface.TRUST_WARN_MAX_VALUE);
 
         // endregion
 
@@ -3170,6 +3188,7 @@ public final class LineageSettings {
             VALIDATORS.put(NETWORK_TRAFFIC_UNITS, NETWORK_TRAFFIC_UNITS_VALIDATOR);
             VALIDATORS.put(NETWORK_TRAFFIC_SHOW_UNITS, NETWORK_TRAFFIC_SHOW_UNITS_VALIDATOR);
             VALIDATORS.put(TRUST_NOTIFICATIONS, TRUST_NOTIFICATIONS_VALIDATOR);
+            VALIDATORS.put(TRUST_WARNINGS, TRUST_WARNINGS_VALIDATOR);
         }
 
         /**

--- a/sdk/src/java/lineageos/trust/ITrustInterface.aidl
+++ b/sdk/src/java/lineageos/trust/ITrustInterface.aidl
@@ -23,4 +23,5 @@ interface ITrustInterface {
     boolean postNotificationForFeature(int feature);
     boolean removeNotificationForFeature(int feature);
     int getLevelForFeature(int feature);
+    void runTest();
 }

--- a/sdk/src/java/lineageos/trust/TrustInterface.java
+++ b/sdk/src/java/lineageos/trust/TrustInterface.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, The LineageOS Project
+ * Copyright (c) 2018, The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,6 +140,49 @@ public class TrustInterface {
      */
     public static final int TRUST_FEATURE_KEYS = 5;
 
+    /**
+     * Trust warning: SELinux
+     *
+     * When {@link #TRUST_FEATURE_SELINUX} is not {@link #TRUST_FEATURE_LEVEL_GOOD}
+     * notify the user about the issue
+     *
+     * @see #postNotificationForFeature
+     */
+    public static final int TRUST_WARN_SELINUX = 1;
+
+    /**
+     * Trust warning: Root access
+     *
+     * When {@link #TRUST_FEATURE_ROOT} is not {@link #TRUST_FEATURE_LEVEL_GOOD}
+     * notify the user about the issue
+     *
+     * @see #postNotificationForFeature
+     */
+    public static final int TRUST_WARN_ROOT = 1 << 1;
+
+    /**
+     * Trust warning: Public Key build signature
+     *
+     * When {@link #TRUST_FEATURE_KEYS} is not {@link #TRUST_FEATURE_LEVEL_GOOD}
+     * notify the user about the issue
+     *
+     * @see #postNotificationForFeature
+     */
+    public static final int TRUST_WARN_PUBLIC_KEY = 1 << 2;
+
+    /**
+     * Max / default value for warnings status
+     *
+     * Includes all the TRUST_WARN_
+     *
+     * @see #postNotificationForFeature
+     * @hide
+     */
+    public static final int TRUST_WARN_MAX_VALUE =
+            TRUST_WARN_SELINUX |
+            TRUST_WARN_ROOT |
+            TRUST_WARN_PUBLIC_KEY;
+
     private static final String TAG = "TrustInterface";
 
     private static ITrustInterface sService;
@@ -223,6 +266,19 @@ public class TrustInterface {
             Log.e(TAG, e.getLocalizedMessage(), e);
         }
         return ERROR_UNDEFINED;
+    }
+
+    /** @hide */
+    public void runTest() {
+        if (sService == null) {
+            return;
+        }
+        try {
+            sService.runTest();
+        } catch (RemoteException e) {
+            Log.e(TAG, e.getLocalizedMessage(), e);
+        }
+        return;
     }
 }
 


### PR DESCRIPTION
Allow fine-tuned management of trust warnings,
the user is now able to disable specific warnings
instead of blocking everything

Change-Id: I04c7aa5fba76fd7500fd70c0c874fa0c3e59e03a
Signed-off-by: Joey <joey@lineageos.org>