### PR TITLE
sdk: Make smarter low-power display mode choices

### DIFF
--- a/lineage/lib/main/java/org/lineageos/platform/internal/display/DisplayHardwareController.java
+++ b/lineage/lib/main/java/org/lineageos/platform/internal/display/DisplayHardwareController.java
@@ -231,8 +231,7 @@ public class DisplayHardwareController extends LiveDisplayFeature {
         if (!mUseAutoContrast) {
             return;
         }
-        mHardware.set(LineageHardwareManager.FEATURE_AUTO_CONTRAST,
-                !isLowPowerMode() && isAutoContrastEnabled());
+        mHardware.set(LineageHardwareManager.FEATURE_AUTO_CONTRAST, isAutoContrastEnabled());
     }
 
     /**
@@ -243,7 +242,7 @@ public class DisplayHardwareController extends LiveDisplayFeature {
             return;
         }
         mHardware.set(LineageHardwareManager.FEATURE_COLOR_ENHANCEMENT,
-                !isLowPowerMode() && isColorEnhancementEnabled());
+                (!isLowPowerMode() || mDefaultColorEnhancement) && isColorEnhancementEnabled());
     }
 
     /**
@@ -253,8 +252,7 @@ public class DisplayHardwareController extends LiveDisplayFeature {
         if (!mUseCABC) {
             return;
         }
-        mHardware.set(LineageHardwareManager.FEATURE_ADAPTIVE_BACKLIGHT,
-                !isLowPowerMode() && isCABCEnabled());
+        mHardware.set(LineageHardwareManager.FEATURE_ADAPTIVE_BACKLIGHT, isCABCEnabled());
     }
 
     private synchronized void updateColorAdjustment() {


### PR DESCRIPTION
* Keep CABC in low-power mode, it helps save battery
* Keep ACO in low-power mode, it helps save battery
* Only disable color enhancement if it's not the default,
  because some devices *need* color enhancement enabled

Change-Id: Id8c47bdf06782d783e175cd679847c227f3b3636