### PR TITLE
sdk: Allow controllable brightness for non-RGB segmented battery LEDs

### DIFF
--- a/sdk/src/java/org/lineageos/internal/notification/LineageBatteryLights.java
+++ b/sdk/src/java/org/lineageos/internal/notification/LineageBatteryLights.java
@@ -180,11 +180,19 @@ public final class LineageBatteryLights {
         if (ledValues.getColor() != 0) {
             ledValues.setEnabled(true);
         }
-        // If lights HAL does not support adjustable brightness then
-        // scale color value here instead.
-        if (mCanAdjustBrightness && !mHALAdjustableBrightness) {
-            ledValues.applyAlphaToBrightness();
-            ledValues.applyBrightnessToColor();
+        if (mCanAdjustBrightness) {
+            if (!mHALAdjustableBrightness) {
+                // If lights HAL does not support adjustable brightness then
+                // scale color value here instead.
+                ledValues.applyAlphaToBrightness();
+                ledValues.applyBrightnessToColor();
+            } else if (mUseSegmentedBatteryLed && !mMultiColorBatteryLed) {
+                // For non-RGB segmented LEDs, we must set the brightness as the
+                // color, since the alpha channel contains the battery level
+                int segmentLevel = mZenMode == Global.ZEN_MODE_OFF
+                        ? mBatteryBrightnessLevel : mBatteryBrightnessZenLevel;
+                ledValues.setColor(segmentLevel | (segmentLevel << 8) | (segmentLevel << 16));
+            }
         }
         // If LED is segmented, reset brightness field to battery level
         // (applyBrightnessToColor() changes it to 255)


### PR DESCRIPTION
* For non-RGB segmented battery LEDs, we currently don't allow any kind
  of brightness control, because the alpha channel is taken up by the level
* To remedy this, set the brightness in the color channel like we do for
  setting panel backlight brightness by setting the brightness as R/G/B

Change-Id: I4e47861643e0b2b8766af0f2ff275069fc580108