### PR TITLE
Regen lineage_current

### DIFF
--- a/api/lineage_current.txt
+++ b/api/lineage_current.txt
@@ -212,7 +212,6 @@ package lineageos.hardware {
     method public boolean setDisplayColorCalibration(int[]);
     method public deprecated boolean setDisplayGammaCalibration(int, int[]);
     method public boolean setDisplayMode(lineageos.hardware.DisplayMode, boolean);
-    method public boolean setGrayscale(boolean);
     method public boolean setPictureAdjustment(lineageos.hardware.HSIC);
     method public boolean setTouchscreenGestureEnabled(lineageos.hardware.TouchscreenGesture, boolean);
     method public boolean setVibratorIntensity(int);


### PR DESCRIPTION
*) setGrayscale was removed here:
https://github.com/LineageOS/android_lineage-sdk/commit/505580e2dd4b9f4f27cfe25cb3af9fc04323cae9

Change-Id: If075a093e4e00ab845cd817966df041f5dba71d3